### PR TITLE
StatusDataのジェネリクスを削除

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/example/project/preview/battle/PlayerActionPreview.kt
+++ b/composeApp/src/androidMain/kotlin/org/example/project/preview/battle/PlayerActionPreview.kt
@@ -3,7 +3,6 @@ package org.example.project.preview.battle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.param.StatusParameter
 import core.domain.status.param.StatusParameterWithMax
 import gamescreen.battle.command.playeraction.PlayerAction
@@ -17,7 +16,7 @@ fun PlayerActionPreview(
 ) {
     PlayerAction(
         playerActionViewModel = playerActionViewModel,
-        playerStatus = StatusData<StatusType.Player>(
+        playerStatus = StatusData(
             "test",
             hp = StatusParameterWithMax(
                 maxPoint = 100,

--- a/composeApp/src/commonMain/kotlin/core/ModuleCore.kt
+++ b/composeApp/src/commonMain/kotlin/core/ModuleCore.kt
@@ -1,6 +1,5 @@
 package core
 
-import core.domain.status.StatusType
 import core.repository.bag.BagRepository
 import core.repository.bag.BagRepositoryImpl
 import core.repository.battlemonster.BattleInfoRepository
@@ -53,7 +52,7 @@ val EquipmentBagRepositoryName = named(
 )
 
 val ModuleCore = module {
-    single<StatusDataRepository<StatusType.Player>>(
+    single<StatusDataRepository>(
         qualifier = PlayerStatusRepositoryName
     ) {
         StatusDataRepositoryImpl()
@@ -69,7 +68,7 @@ val ModuleCore = module {
         BattleInfoRepositoryImpl()
     }
 
-    single<StatusDataRepository<StatusType.Enemy>>(
+    single<StatusDataRepository>(
         qualifier = EnemyStatusRepositoryName
     ) {
         StatusDataRepositoryImpl()
@@ -106,7 +105,7 @@ val ModuleCore = module {
         )
     }
 
-    single<UpdateStatusUseCase<StatusType.Player>>(
+    single<UpdateStatusUseCase>(
         qualifier = named(UpdatePlayer)
     ) {
         UpdateStatusUseCaseImpl(
@@ -116,7 +115,7 @@ val ModuleCore = module {
         )
     }
 
-    single<UpdateStatusUseCase<StatusType.Enemy>>(
+    single<UpdateStatusUseCase>(
         qualifier = UpdateEnemyUseCaseName,
     )
     {

--- a/composeApp/src/commonMain/kotlin/core/domain/item/TargetStatusType.kt
+++ b/composeApp/src/commonMain/kotlin/core/domain/item/TargetStatusType.kt
@@ -4,13 +4,13 @@ import core.domain.status.StatusData
 
 enum class TargetStatusType {
     ACTIVE {
-        override fun canSelect(status: StatusData<*>): Boolean {
+        override fun canSelect(status: StatusData): Boolean {
             return status.isActive
         }
     },
 
     INACTIVE {
-        override fun canSelect(status: StatusData<*>): Boolean {
+        override fun canSelect(status: StatusData): Boolean {
             return status.isActive.not()
         }
     }
@@ -20,5 +20,5 @@ enum class TargetStatusType {
     /**
      * 対象のstatusが選択可能かどうかを返す
      */
-    abstract fun canSelect(status: StatusData<*>): Boolean
+    abstract fun canSelect(status: StatusData): Boolean
 }

--- a/composeApp/src/commonMain/kotlin/core/domain/status/StatusData.kt
+++ b/composeApp/src/commonMain/kotlin/core/domain/status/StatusData.kt
@@ -5,7 +5,7 @@ import core.domain.status.param.StatusParameter
 import core.domain.status.param.StatusParameterWithMax
 
 // todo statusDataにTを持たせて確認する
-data class StatusData<T : StatusType>(
+data class StatusData(
     val name: String,
     val hp: StatusParameterWithMax<ParameterType.HP> =
         StatusParameterWithMax(
@@ -33,7 +33,7 @@ data class StatusData<T : StatusType>(
     fun setHP(
         value: Int = hp.point,
         max: Int = hp.maxPoint,
-    ): StatusData<T> {
+    ): StatusData {
         return this.copy(
             hp = hp.set(
                 value = value,
@@ -42,13 +42,13 @@ data class StatusData<T : StatusType>(
         )
     }
 
-    fun decHP(amount: Int): StatusData<T> {
+    fun decHP(amount: Int): StatusData {
         return this.copy(
             hp = hp.dec(amount),
         )
     }
 
-    fun incHP(amount: Int): StatusData<T> {
+    fun incHP(amount: Int): StatusData {
         return this.copy(
             hp = hp.inc(amount),
         )
@@ -57,7 +57,7 @@ data class StatusData<T : StatusType>(
     fun setMP(
         value: Int = mp.point,
         max: Int = mp.maxPoint,
-    ): StatusData<T> {
+    ): StatusData {
         return this.copy(
             mp = mp.set(
                 value = value,
@@ -66,25 +66,25 @@ data class StatusData<T : StatusType>(
         )
     }
 
-    fun decMP(amount: Int): StatusData<T> {
+    fun decMP(amount: Int): StatusData {
         return this.copy(
             mp = mp.dec(amount),
         )
     }
 
-    fun incMP(amount: Int): StatusData<T> {
+    fun incMP(amount: Int): StatusData {
         return this.copy(
             mp = mp.inc(amount),
         )
     }
 
-    fun updateConditionList(conditionList: List<ConditionType>): StatusData<T> {
+    fun updateConditionList(conditionList: List<ConditionType>): StatusData {
         return copy(
             conditionList = conditionList,
         )
     }
 
-    fun addConditionType(conditionType: ConditionType): StatusData<T> {
+    fun addConditionType(conditionType: ConditionType): StatusData {
         return this.copy(
             conditionList = conditionList + conditionType,
         )
@@ -95,7 +95,7 @@ data class StatusData<T : StatusType>(
      */
     fun incStatus(
         statusIncrease: StatusIncrease,
-    ): StatusData<T> {
+    ): StatusData {
         return copy(
             hp = hp.incMax(statusIncrease.hp),
             mp = mp.incMax(statusIncrease.mp),
@@ -110,7 +110,7 @@ data class StatusData<T : StatusType>(
      */
     fun decStatus(
         statusIncrease: StatusIncrease,
-    ): StatusData<T> {
+    ): StatusData {
         return copy(
             hp = hp.decMax(statusIncrease.hp),
             mp = mp.decMax(statusIncrease.mp),
@@ -120,7 +120,7 @@ data class StatusData<T : StatusType>(
         )
     }
 
-    fun reduceBuf(): StatusData<T> {
+    fun reduceBuf(): StatusData {
         return copy(
             atk = atk.reduceBuf(),
             def = def.reduceBuf(),

--- a/composeApp/src/commonMain/kotlin/core/repository/statusdata/StatusDataRepository.kt
+++ b/composeApp/src/commonMain/kotlin/core/repository/statusdata/StatusDataRepository.kt
@@ -1,21 +1,20 @@
 package core.repository.statusdata
 
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import kotlinx.coroutines.flow.StateFlow
 
-interface StatusDataRepository<T : StatusType> {
+interface StatusDataRepository {
 
-    val statusDataFlow: StateFlow<List<StatusData<T>>>
+    val statusDataFlow: StateFlow<List<StatusData>>
 
-    fun getStatusData(id: Int): StatusData<T>
+    fun getStatusData(id: Int): StatusData
 
     fun setStatusData(
         id: Int,
-        statusData: StatusData<T>,
+        statusData: StatusData,
     )
 
-    fun getStatusList(): List<StatusData<T>>
+    fun getStatusList(): List<StatusData>
 
-    fun setStatusList(statusList: List<StatusData<T>>)
+    fun setStatusList(statusList: List<StatusData>)
 }

--- a/composeApp/src/commonMain/kotlin/core/repository/statusdata/StatusDataRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/core/repository/statusdata/StatusDataRepositoryImpl.kt
@@ -1,26 +1,25 @@
 package core.repository.statusdata
 
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class StatusDataRepositoryImpl<T : StatusType> : StatusDataRepository<T> {
-    private val mutableStatusData: MutableStateFlow<List<StatusData<T>>> = MutableStateFlow(
+class StatusDataRepositoryImpl : StatusDataRepository {
+    private val mutableStatusData: MutableStateFlow<List<StatusData>> = MutableStateFlow(
         emptyList()
     )
 
-    override val statusDataFlow: StateFlow<List<StatusData<T>>>
+    override val statusDataFlow: StateFlow<List<StatusData>>
         get() = mutableStatusData.asStateFlow()
 
-    override fun getStatusData(id: Int): StatusData<T> {
+    override fun getStatusData(id: Int): StatusData {
         return statusDataFlow.value[id]
     }
 
     override fun setStatusData(
         id: Int,
-        statusData: StatusData<T>,
+        statusData: StatusData,
     ) {
         val list = statusDataFlow.value.toMutableList()
 
@@ -29,11 +28,11 @@ class StatusDataRepositoryImpl<T : StatusType> : StatusDataRepository<T> {
         mutableStatusData.value = list
     }
 
-    override fun getStatusList(): List<StatusData<T>> {
+    override fun getStatusList(): List<StatusData> {
         return statusDataFlow.value
     }
 
-    override fun setStatusList(statusList: List<StatusData<T>>) {
+    override fun setStatusList(statusList: List<StatusData>) {
         mutableStatusData.value = statusList
     }
 }

--- a/composeApp/src/commonMain/kotlin/core/service/CheckCanUseService.kt
+++ b/composeApp/src/commonMain/kotlin/core/service/CheckCanUseService.kt
@@ -5,7 +5,7 @@ import core.domain.status.StatusData
 
 interface CheckCanUseService {
     operator fun invoke(
-        status: StatusData<*>,
+        status: StatusData,
         costType: CostType,
     ): Boolean
 }

--- a/composeApp/src/commonMain/kotlin/core/service/CheckCanUseServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/core/service/CheckCanUseServiceImpl.kt
@@ -5,7 +5,7 @@ import core.domain.status.StatusData
 
 class CheckCanUseServiceImpl : CheckCanUseService {
     override fun invoke(
-        status: StatusData<*>,
+        status: StatusData,
         costType: CostType,
     ): Boolean {
         return when (costType) {

--- a/composeApp/src/commonMain/kotlin/core/usecase/equipment/EquipUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/core/usecase/equipment/EquipUseCaseImpl.kt
@@ -1,7 +1,6 @@
 package core.usecase.equipment
 
 import core.domain.item.equipment.EquipmentType
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.repository.statusdata.StatusDataRepository
 import data.item.equipment.EquipmentId
@@ -9,7 +8,7 @@ import data.item.equipment.EquipmentRepository
 
 class EquipUseCaseImpl(
     private val playerStatusRepository: PlayerStatusRepository,
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 
     private val equipmentRepository: EquipmentRepository,
 ) : EquipUseCase {

--- a/composeApp/src/commonMain/kotlin/core/usecase/heal/MaxHealUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/core/usecase/heal/MaxHealUseCaseImpl.kt
@@ -1,10 +1,9 @@
 package core.usecase.heal
 
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 
 class MaxHealUseCaseImpl(
-    private val playerStatusRepository: StatusDataRepository<StatusType.Player>,
+    private val playerStatusRepository: StatusDataRepository,
 ) : MaxHealUseCase {
     override suspend fun invoke() {
         playerStatusRepository.getStatusList().mapIndexed { index, playerStatus ->

--- a/composeApp/src/commonMain/kotlin/core/usecase/item/checkcanuseskill/CheckCanUseSkillUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/core/usecase/item/checkcanuseskill/CheckCanUseSkillUseCase.kt
@@ -8,7 +8,7 @@ import data.item.skill.SkillId
 interface CheckCanUseSkillUseCase {
     operator fun invoke(
         skillId: SkillId,
-        status: StatusData<*>,
+        status: StatusData,
         here: Place,
     ): AbleType
 }

--- a/composeApp/src/commonMain/kotlin/core/usecase/item/checkcanuseskill/CheckCanUseSkillUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/core/usecase/item/checkcanuseskill/CheckCanUseSkillUseCaseImpl.kt
@@ -13,7 +13,7 @@ class CheckCanUseSkillUseCaseImpl(
 ) : CheckCanUseSkillUseCase {
     override fun invoke(
         skillId: SkillId,
-        status: StatusData<*>,
+        status: StatusData,
         here: Place,
     ): AbleType {
         val skill = skillRepository.getItem(skillId)

--- a/composeApp/src/commonMain/kotlin/core/usecase/item/useskill/UseSkillUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/core/usecase/item/useskill/UseSkillUseCaseImpl.kt
@@ -3,7 +3,6 @@ package core.usecase.item.useskill
 import core.domain.item.CostType
 import core.domain.item.skill.AttackSkill
 import core.domain.item.skill.HealSkill
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.usecase.updateparameter.UpdateStatusUseCase
 import data.item.skill.SkillRepository
@@ -11,7 +10,7 @@ import data.item.skill.SkillRepository
 class UseSkillUseCaseImpl(
     private val playerStatusRepository: PlayerStatusRepository,
     private val skillRepository: SkillRepository,
-    private val updateStatus: UpdateStatusUseCase<StatusType.Player>,
+    private val updateStatus: UpdateStatusUseCase,
 ) : UseSkillUseCase {
     override suspend fun invoke(
         userId: Int,

--- a/composeApp/src/commonMain/kotlin/core/usecase/item/usetool/UseToolUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/core/usecase/item/usetool/UseToolUseCaseImpl.kt
@@ -2,7 +2,6 @@ package core.usecase.item.usetool
 
 import core.domain.item.CostType
 import core.domain.item.tool.HealTool
-import core.domain.status.StatusType
 import core.usecase.updateparameter.UpdatePlayerStatusUseCase
 import core.usecase.updateparameter.UpdateStatusUseCase
 import data.item.tool.ToolId
@@ -18,7 +17,7 @@ import values.Constants
 class UseToolUseCaseImpl(
     private val toolRepository: ToolRepository,
     private val updatePlayerStatusUseCase: UpdatePlayerStatusUseCase,
-    private val updateStatusUseCase: UpdateStatusUseCase<StatusType.Player>,
+    private val updateStatusUseCase: UpdateStatusUseCase,
 
     private val decToolUseCase: DecToolUseCase,
     private val getToolIdUseCase: GetToolIdUseCase,

--- a/composeApp/src/commonMain/kotlin/core/usecase/updateparameter/UpdateStatusUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/core/usecase/updateparameter/UpdateStatusUseCase.kt
@@ -2,9 +2,8 @@ package core.usecase.updateparameter
 
 import core.domain.item.BufEffect
 import core.domain.status.ConditionType
-import core.domain.status.StatusType
 
-interface UpdateStatusUseCase<T : StatusType> {
+interface UpdateStatusUseCase {
     /**
      *  HPを減らして、更新後のステータスを返す
      */

--- a/composeApp/src/commonMain/kotlin/core/usecase/updateparameter/UpdateStatusUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/core/usecase/updateparameter/UpdateStatusUseCaseImpl.kt
@@ -2,13 +2,12 @@ package core.usecase.updateparameter
 
 import core.domain.item.BufEffect
 import core.domain.status.ConditionType
-import core.domain.status.StatusType
 import core.domain.status.param.ParameterType
 import core.repository.statusdata.StatusDataRepository
 
-class UpdateStatusUseCaseImpl<T : StatusType>(
-    private val statusDataRepository: StatusDataRepository<T>,
-) : UpdateStatusUseCase<T> {
+class UpdateStatusUseCaseImpl(
+    private val statusDataRepository: StatusDataRepository,
+) : UpdateStatusUseCase {
     override suspend fun decHP(
         id: Int,
         amount: Int,

--- a/composeApp/src/commonMain/kotlin/data/battle/EventBattleData.kt
+++ b/composeApp/src/commonMain/kotlin/data/battle/EventBattleData.kt
@@ -2,12 +2,11 @@ package data.battle
 
 import core.domain.BattleEventCallback
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import gamescreen.battle.domain.BattleBackgroundType
 
 data class EventBattleData(
-    val monsterList: List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>>,
+    val monsterList: List<Pair<MonsterStatus, StatusData>>,
     val battleEventCallback: BattleEventCallback,
     val battleBackgroundType: BattleBackgroundType,
 )

--- a/composeApp/src/commonMain/kotlin/data/monster/MonsterRepository.kt
+++ b/composeApp/src/commonMain/kotlin/data/monster/MonsterRepository.kt
@@ -1,10 +1,9 @@
 package data.monster
 
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 
 interface MonsterRepository {
 
-    fun getMonster(id: Int): Pair<MonsterStatus, StatusData<StatusType.Enemy>>
+    fun getMonster(id: Int): Pair<MonsterStatus, StatusData>
 }

--- a/composeApp/src/commonMain/kotlin/data/monster/MonsterRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/data/monster/MonsterRepositoryImpl.kt
@@ -2,7 +2,6 @@ package data.monster
 
 import core.domain.status.DropItemInfo
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.ActionStyle
 import core.domain.status.monster.MonsterStatus
 import core.domain.status.param.StatusParameter
@@ -11,7 +10,7 @@ import data.item.skill.SkillId
 import data.item.tool.ToolId
 
 class MonsterRepositoryImpl : MonsterRepository {
-    override fun getMonster(id: Int): Pair<MonsterStatus, StatusData<StatusType.Enemy>> {
+    override fun getMonster(id: Int): Pair<MonsterStatus, StatusData> {
         // fixme モンスターの種類を増やす
         return Pair(
             MonsterStatus(

--- a/composeApp/src/commonMain/kotlin/data/status/AbstractStatusRepository.kt
+++ b/composeApp/src/commonMain/kotlin/data/status/AbstractStatusRepository.kt
@@ -3,14 +3,13 @@ package data.status
 import core.domain.status.PlayerStatus
 import core.domain.status.StatusData
 import core.domain.status.StatusIncrease
-import core.domain.status.StatusType
 
 abstract class AbstractStatusRepository : StatusRepository {
 
     override fun getStatus(
         id: Int,
         level: Int,
-    ): Pair<PlayerStatus, StatusData<StatusType.Player>> {
+    ): Pair<PlayerStatus, StatusData> {
         var (playerStatus, statusData) = statusBaseList[id]
 
         for (lv: Int in 0 until level) {
@@ -38,5 +37,5 @@ abstract class AbstractStatusRepository : StatusRepository {
 
     protected abstract val statusUpList: List<List<StatusIncrease>>
 
-    protected abstract val statusBaseList: List<Pair<PlayerStatus, StatusData<StatusType.Player>>>
+    protected abstract val statusBaseList: List<Pair<PlayerStatus, StatusData>>
 }

--- a/composeApp/src/commonMain/kotlin/data/status/StatusRepository.kt
+++ b/composeApp/src/commonMain/kotlin/data/status/StatusRepository.kt
@@ -2,12 +2,11 @@ package data.status
 
 import core.domain.status.PlayerStatus
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 
 interface StatusRepository {
 
     fun getStatus(
         id: Int,
         level: Int,
-    ): Pair<PlayerStatus, StatusData<StatusType.Player>>
+    ): Pair<PlayerStatus, StatusData>
 }

--- a/composeApp/src/commonMain/kotlin/data/status/StatusRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/data/status/StatusRepositoryImpl.kt
@@ -4,7 +4,6 @@ import core.domain.status.IncData
 import core.domain.status.PlayerStatus
 import core.domain.status.StatusData
 import core.domain.status.StatusIncrease
-import core.domain.status.StatusType
 import core.domain.status.param.EXP
 import data.item.skill.SkillId
 import data.item.tool.ToolId
@@ -66,7 +65,7 @@ class StatusRepositoryImpl : AbstractStatusRepository() {
         }
     }
 
-    override val statusBaseList: List<Pair<PlayerStatus, StatusData<StatusType.Player>>> = List(3) {
+    override val statusBaseList: List<Pair<PlayerStatus, StatusData>> = List(3) {
         when (it) {
             0 ->
                 Pair(

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/BattleViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/BattleViewModel.kt
@@ -4,7 +4,6 @@ import controller.domain.ControllerCallback
 import controller.domain.Stick
 import core.EnemyStatusRepositoryName
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import core.repository.battlemonster.BattleInfoRepository
 import core.repository.statusdata.StatusDataRepository
@@ -20,13 +19,13 @@ class BattleViewModel(
     flashRepository: FlashRepository,
     attackEffectInfoRepository: AttackEffectRepository,
 
-    statusDataRepository: StatusDataRepository<StatusType.Player>,
+    statusDataRepository: StatusDataRepository,
 ) :
     ControllerCallback,
     KoinComponent {
 
     private val battleInfoRepository: BattleInfoRepository by inject()
-    private val monsterStatusRepository: StatusDataRepository<StatusType.Enemy> by inject(qualifier = EnemyStatusRepositoryName)
+    private val monsterStatusRepository: StatusDataRepository by inject(qualifier = EnemyStatusRepositoryName)
 
     private val commandStateRepository: CommandStateRepository by inject()
 
@@ -39,12 +38,12 @@ class BattleViewModel(
         commandStateRepository.commandStateFlow
 
     // todo playerにrename
-    val statusDataFlow: StateFlow<List<StatusData<StatusType.Player>>> =
+    val statusDataFlow: StateFlow<List<StatusData>> =
         statusDataRepository.statusDataFlow
 
     val monsterStatusFlow: StateFlow<List<MonsterStatus>> =
         battleInfoRepository.monsterListStateFLow
-    val monsterStatusDataFlow: StateFlow<List<StatusData<StatusType.Enemy>>> = monsterStatusRepository.statusDataFlow
+    val monsterStatusDataFlow: StateFlow<List<StatusData>> = monsterStatusRepository.statusDataFlow
 
     val battleBackgroundTypeFlow =
         battleInfoRepository.backgroundType

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/ModuleBattle.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/ModuleBattle.kt
@@ -4,7 +4,6 @@ import core.EnemyStatusRepositoryName
 import core.PlayerStatusRepositoryName
 import core.UpdateEnemyUseCaseName
 import core.UpdatePlayer
-import core.domain.status.StatusType
 import gamescreen.battle.command.actionphase.ActionPhaseViewModel
 import gamescreen.battle.command.escape.EscapeViewModel
 import gamescreen.battle.command.finish.BattleFinishViewModel
@@ -175,7 +174,7 @@ val ModuleBattle = module {
         DecideActionOrderUseCaseImpl()
     }
 
-    single<AttackUseCase<StatusType.Player>>(
+    single<AttackUseCase>(
         qualifier = named(QualifierAttackFromPlayer)
     ) {
         AttackFromPlayerUseCaseImpl(
@@ -202,7 +201,7 @@ val ModuleBattle = module {
         )
     }
 
-    single<AttackUseCase<StatusType.Enemy>>(
+    single<AttackUseCase>(
         qualifier = named(QualifierAttackFromEnemy)
     )
     {

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/StatusDebugInfo.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/StatusDebugInfo.kt
@@ -17,7 +17,7 @@ import values.Colors
 
 @Composable
 fun StatusDebugInfo(
-    statusData: StatusData<*>,
+    statusData: StatusData,
     size: Int,
     modifier: Modifier = Modifier,
 ) {

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/command/actionphase/ActionPhaseViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/command/actionphase/ActionPhaseViewModel.kt
@@ -54,8 +54,8 @@ import values.Constants.Companion.playerNum
 class ActionPhaseViewModel(
     private val decideActionOrderUseCase: DecideActionOrderUseCase,
 
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
-    private val enemyDataRepository: StatusDataRepository<StatusType.Enemy>,
+    private val statusDataRepository: StatusDataRepository,
+    private val enemyDataRepository: StatusDataRepository,
 ) : BattleChildViewModel() {
     private val actionRepository: ActionRepository by inject()
     private val battleInfoRepository: BattleInfoRepository by inject()
@@ -64,14 +64,14 @@ class ActionPhaseViewModel(
     private val skillRepository: SkillRepository by inject()
     private val toolRepository: ToolRepository by inject()
 
-    private val updatePlayerParameter: UpdateStatusUseCase<StatusType.Player> by inject(
+    private val updatePlayerParameter: UpdateStatusUseCase by inject(
         qualifier = named(UpdatePlayer)
     )
-    private val updateEnemyParameter: UpdateStatusUseCase<StatusType.Enemy> by inject(
+    private val updateEnemyParameter: UpdateStatusUseCase by inject(
         qualifier = UpdateEnemyUseCaseName,
     )
 
-    private val attackFromPlayerUseCase: AttackUseCase<StatusType.Player> by inject(
+    private val attackFromPlayerUseCase: AttackUseCase by inject(
         qualifier = named(
             QualifierAttackFromPlayer
         )
@@ -81,7 +81,7 @@ class ActionPhaseViewModel(
         qualifier = named(QualifierAttackFromPlayer)
     )
 
-    private val attackFromEnemyUseCase: AttackUseCase<StatusType.Enemy> by inject(
+    private val attackFromEnemyUseCase: AttackUseCase by inject(
         qualifier = named(QualifierAttackFromEnemy)
     )
     private val conditionFromEnemyUseCase: ConditionUseCase by inject(
@@ -225,7 +225,7 @@ class ActionPhaseViewModel(
     /**
      * statusWrapperを入れて対応するステータスを取得
      */
-    private fun getStatus(statusWrapper: StatusWrapper): StatusData<*> {
+    private fun getStatus(statusWrapper: StatusWrapper): StatusData {
         return when (statusWrapper.statusType) {
             StatusType.Player -> statusDataRepository
             StatusType.Enemy -> enemyDataRepository
@@ -347,7 +347,7 @@ class ActionPhaseViewModel(
                 //　攻撃
                 attackFromPlayerUseCase.invoke(
                     target = actionRepository.getAction(actionStatusWrapper.newId).target,
-                    attacker = (getStatus(actionStatusWrapper) as StatusData<StatusType.Player>),
+                    attacker = getStatus(actionStatusWrapper),
                     damageType = DamageType.AtkMultiple(1),
                 )
             }
@@ -355,7 +355,7 @@ class ActionPhaseViewModel(
             ActionType.Skill -> {
                 skillAction(
                     id = actionStatusWrapper.newId,
-                    statusData = getStatus(actionStatusWrapper) as StatusData<StatusType.Player>,
+                    statusData = getStatus(actionStatusWrapper),
                     actionData = actionRepository.getAction(actionStatusWrapper.newId),
                     statusList = enemyDataRepository.getStatusList(),
                     attackUseCase = attackFromPlayerUseCase,
@@ -382,7 +382,7 @@ class ActionPhaseViewModel(
         actionStatusWrapper.apply {
             skillAction(
                 id = newId,
-                statusData = getStatus(actionStatusWrapper) as StatusData<StatusType.Enemy>,
+                statusData = getStatus(actionStatusWrapper),
                 statusList = statusDataRepository.getStatusList(),
                 actionData = actionData,
                 attackUseCase = attackFromEnemyUseCase,
@@ -417,15 +417,15 @@ class ActionPhaseViewModel(
         }
     }
 
-    private suspend fun <A : StatusType, E : StatusType> skillAction(
+    private suspend fun skillAction(
         id: Int,
-        statusData: StatusData<A>,
+        statusData: StatusData,
         actionData: ActionData,
-        statusList: List<StatusData<E>>,
-        attackUseCase: AttackUseCase<A>,
+        statusList: List<StatusData>,
+        attackUseCase: AttackUseCase,
         conditionUseCase: ConditionUseCase,
-        updateAllyParameter: UpdateStatusUseCase<A>,
-        updateEnemyParameter: UpdateStatusUseCase<E>,
+        updateAllyParameter: UpdateStatusUseCase,
+        updateEnemyParameter: UpdateStatusUseCase,
     ) {
         val skill = skillRepository.getItem(
             id = actionData.skillId
@@ -680,7 +680,7 @@ class ActionPhaseViewModel(
         private val dummyStatus = StatusWrapper(
             newId = -1,
             statusType = StatusType.None,
-            status = StatusData<StatusType.Player>(name = ""),
+            status = StatusData(name = ""),
             actionData = ActionData(),
         )
     }

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/command/item/ItemCommandViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/command/item/ItemCommandViewModel.kt
@@ -5,7 +5,6 @@ import core.PlayerStatusRepositoryName
 import core.domain.Const
 import core.domain.item.TargetType
 import core.domain.item.UsableItem
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.repository.statusdata.StatusDataRepository
 import data.item.ItemRepository
@@ -24,7 +23,7 @@ abstract class ItemCommandViewModel<T, V : UsableItem> : BattleChildViewModel() 
     protected val actionRepository: ActionRepository by inject()
     protected val playerStatusRepository: PlayerStatusRepository by inject()
 
-    protected val statusDataRepository: StatusDataRepository<StatusType.Player> by inject(
+    protected val statusDataRepository: StatusDataRepository by inject(
         qualifier = PlayerStatusRepositoryName
     )
 

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/command/playeraction/PlayerAction.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/command/playeraction/PlayerAction.kt
@@ -13,12 +13,11 @@ import common.extension.equalAllocationModifier
 import common.extension.menuItem
 import common.layout.CenterText
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import org.koin.compose.koinInject
 
 @Composable
 fun PlayerAction(
-    playerStatus: StatusData<StatusType.Player>,
+    playerStatus: StatusData,
     modifier: Modifier = Modifier,
     playerActionViewModel: PlayerActionViewModel = koinInject(),
 ) {

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/command/playeraction/PlayerActionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/command/playeraction/PlayerActionViewModel.kt
@@ -1,6 +1,5 @@
 package gamescreen.battle.command.playeraction
 
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import gamescreen.battle.BattleChildViewModel
 import gamescreen.battle.domain.ActionType
@@ -17,7 +16,7 @@ import org.koin.core.component.inject
 
 // TODO: test作る 
 class PlayerActionViewModel(
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 ) : BattleChildViewModel() {
     private val actionRepository: ActionRepository by inject()
 

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/command/selectally/SelectAllyCommandWindow.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/command/selectally/SelectAllyCommandWindow.kt
@@ -5,13 +5,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import common.layout.CenterText
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import gamescreen.battle.command.selectenemy.SelectEnemyViewModel
 import org.koin.compose.koinInject
 
 @Composable
 fun SelectAllyCommandWindow(
-    playerStatus: StatusData<StatusType.Player>,
+    playerStatus: StatusData,
     modifier: Modifier = Modifier,
     selectEnemyViewModel: SelectEnemyViewModel = koinInject(),
 ) {

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/command/selectally/SelectAllyViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/command/selectally/SelectAllyViewModel.kt
@@ -2,7 +2,6 @@ package gamescreen.battle.command.selectally
 
 import common.DefaultScope
 import core.domain.item.TargetStatusType
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import data.item.skill.SkillRepository
 import data.item.tool.ToolRepository
@@ -21,7 +20,7 @@ import values.Constants.Companion.playerNum
 
 // test作る
 class SelectAllyViewModel(
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 ) : BattleChildViewModel() {
     private val changeSelectingActionPlayerUseCase: ChangeSelectingActionPlayerUseCase by inject()
     private val actionRepository: ActionRepository by inject()

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/command/selectenemy/SelectEnemy.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/command/selectenemy/SelectEnemy.kt
@@ -7,12 +7,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import org.koin.compose.koinInject
 
 @Composable
 fun SelectEnemy(
-    playerStatus: StatusData<StatusType.Player>,
+    playerStatus: StatusData,
     modifier: Modifier = Modifier,
     selectEnemyViewModel: SelectEnemyViewModel = koinInject(),
 ) {

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/command/selectenemy/SelectEnemyViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/command/selectenemy/SelectEnemyViewModel.kt
@@ -4,7 +4,6 @@ import common.DefaultScope
 import controller.domain.ArrowCommand
 import controller.domain.Stick
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import gamescreen.battle.BattleChildViewModel
 import gamescreen.battle.domain.BattleCommandType
@@ -23,7 +22,7 @@ import kotlinx.coroutines.launch
 import org.koin.core.component.inject
 
 class SelectEnemyViewModel(
-    private val enemyStatusDataRepository: StatusDataRepository<StatusType.Enemy>,
+    private val enemyStatusDataRepository: StatusDataRepository,
 ) : BattleChildViewModel() {
     private val actionRepository: ActionRepository by inject()
 
@@ -52,7 +51,7 @@ class SelectEnemyViewModel(
         }
     }
 
-    private val monsters: List<StatusData<StatusType.Enemy>>
+    private val monsters: List<StatusData>
         get() = enemyStatusDataRepository.getStatusList()
 
     override fun isBoundedImpl(commandType: BattleCommandType): Boolean {

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/domain/StatusWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/domain/StatusWrapper.kt
@@ -5,7 +5,7 @@ import core.domain.status.StatusType
 
 
 data class StatusWrapper(
-    val status: StatusData<*>,
+    val status: StatusData,
     val actionData: ActionData,
     val statusType: StatusType,
     val newId: Int,

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/monster/MonsterArea.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/monster/MonsterArea.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import gamescreen.battle.StatusDebugInfo
 import gamescreen.battle.command.selectenemy.SelectEnemyViewModel
@@ -38,7 +37,7 @@ import org.koin.compose.koinInject
 fun MonsterArea(
     // fixme imgIDだけ渡す
     monsters: List<MonsterStatus>,
-    monsterStatusList: List<StatusData<StatusType.Enemy>>,
+    monsterStatusList: List<StatusData>,
     flashState: List<FlashInfo>,
     attackEffectInfo: List<AttackEffectInfo>,
     modifier: Modifier = Modifier,

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/service/attackcalc/AttackCalcService.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/service/attackcalc/AttackCalcService.kt
@@ -2,12 +2,11 @@ package gamescreen.battle.service.attackcalc
 
 import core.domain.item.DamageType
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 
 interface AttackCalcService {
-    operator fun <T : StatusType> invoke(
-        attacker: StatusData<*>,
-        attacked: StatusData<T>,
+    operator fun invoke(
+        attacker: StatusData,
+        attacked: StatusData,
         damageType: DamageType,
-    ): StatusData<T>
+    ): StatusData
 }

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/service/attackcalc/AttackCalcServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/service/attackcalc/AttackCalcServiceImpl.kt
@@ -2,16 +2,15 @@ package gamescreen.battle.service.attackcalc
 
 import core.domain.item.DamageType
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import kotlin.math.max
 
 class AttackCalcServiceImpl : AttackCalcService {
 
-    override fun <T : StatusType> invoke(
-        attacker: StatusData<*>,
-        attacked: StatusData<T>,
+    override fun invoke(
+        attacker: StatusData,
+        attacked: StatusData,
         damageType: DamageType,
-    ): StatusData<T> {
+    ): StatusData {
         return when (damageType) {
             is DamageType.AtkMultiple -> attacked.decHP(
                 max(

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/service/findtarget/FindTargetService.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/service/findtarget/FindTargetService.kt
@@ -5,12 +5,12 @@ import core.domain.status.StatusData
 interface FindTargetService {
 
     fun findNext(
-        statusList: List<StatusData<*>>,
+        statusList: List<StatusData>,
         target: Int,
     ): Int
 
     fun findPrev(
-        statusList: List<StatusData<*>>,
+        statusList: List<StatusData>,
         target: Int,
     ): Int
 }

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/service/findtarget/FindTargetServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/service/findtarget/FindTargetServiceImpl.kt
@@ -5,7 +5,7 @@ import core.domain.status.StatusData
 class FindTargetServiceImpl : FindTargetService {
 
     override fun findNext(
-        statusList: List<StatusData<*>>,
+        statusList: List<StatusData>,
         target: Int,
     ): Int {
         var actualTarget = target + 1
@@ -24,7 +24,7 @@ class FindTargetServiceImpl : FindTargetService {
     }
 
     override fun findPrev(
-        statusList: List<StatusData<*>>,
+        statusList: List<StatusData>,
         target: Int,
     ): Int {
         var actualTarget = collectTarget(

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/service/isannihilation/IsAnnihilationService.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/service/isannihilation/IsAnnihilationService.kt
@@ -8,6 +8,6 @@ interface IsAnnihilationService {
      * 入力したstatusが全滅しているかどうかをチェックする
      */
     operator fun invoke(
-        statusList: List<StatusData<*>>,
+        statusList: List<StatusData>,
     ): Boolean
 }

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/service/isannihilation/IsAnnihilationServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/service/isannihilation/IsAnnihilationServiceImpl.kt
@@ -4,7 +4,7 @@ import core.domain.status.StatusData
 
 class IsAnnihilationServiceImpl : IsAnnihilationService {
     override fun invoke(
-        statusList: List<StatusData<*>>,
+        statusList: List<StatusData>,
     ): Boolean {
         //どれか一つでもActiveであれば全滅はしていない
         return !statusList.any {

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/status/StatusArea.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/status/StatusArea.kt
@@ -7,11 +7,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 
 @Composable
 fun StatusArea(
-    statusList: List<StatusData<StatusType.Player>>,
+    statusList: List<StatusData>,
     modifier: Modifier = Modifier,
 ) {
     Row(

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/status/StatusComponent.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/status/StatusComponent.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import common.extension.menuItem
 import common.layout.DisableBox
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.param.StatusParameterWithMax
 import gamescreen.battle.StatusDebugInfo
 import gamescreen.battle.command.selectally.SelectAllyViewModel
@@ -28,7 +27,7 @@ import values.Colors
 
 @Composable
 fun StatusComponent(
-    status: StatusData<StatusType.Player>,
+    status: StatusData,
     index: Int,
     modifier: Modifier = Modifier,
     selectAllyViewModel: SelectAllyViewModel = koinInject(),

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/addexp/AddExpUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/addexp/AddExpUseCaseImpl.kt
@@ -1,7 +1,6 @@
 package gamescreen.battle.usecase.addexp
 
 import common.DefaultScope
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.repository.statusdata.StatusDataRepository
 import data.status.StatusRepository
@@ -11,7 +10,7 @@ class AddExpUseCaseImpl(
     private val playerStatusRepository: PlayerStatusRepository,
     private val statusRepository: StatusRepository,
 
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 ) : AddExpUseCase {
     override fun invoke(exp: Int): List<String> {
         val levelUpList: MutableList<String> = mutableListOf()

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/attack/AttackFromEnemyUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/attack/AttackFromEnemyUseCaseImpl.kt
@@ -2,21 +2,20 @@ package gamescreen.battle.usecase.attack
 
 import core.domain.item.DamageType
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import gamescreen.battle.service.attackcalc.AttackCalcService
 import gamescreen.battle.service.findtarget.FindTargetService
 
 class AttackFromEnemyUseCaseImpl(
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 
     private val findTargetService: FindTargetService,
     private val attackCalcService: AttackCalcService,
-) : AttackUseCase<StatusType.Enemy> {
+) : AttackUseCase {
 
     override suspend fun invoke(
         target: Int,
-        attacker: StatusData<StatusType.Enemy>,
+        attacker: StatusData,
         damageType: DamageType,
     ) {
         var actualTarget = target

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/attack/AttackFromPlayerUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/attack/AttackFromPlayerUseCaseImpl.kt
@@ -2,21 +2,20 @@ package gamescreen.battle.usecase.attack
 
 import core.domain.item.DamageType
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import gamescreen.battle.service.attackcalc.AttackCalcService
 import gamescreen.battle.service.findtarget.FindTargetService
 import gamescreen.battle.usecase.effect.EffectUseCase
 
 class AttackFromPlayerUseCaseImpl(
-    private val statusDataRepository: StatusDataRepository<StatusType.Enemy>,
+    private val statusDataRepository: StatusDataRepository,
     private val findTargetService: FindTargetService,
     private val attackCalcService: AttackCalcService,
     private val effectUseCase: EffectUseCase,
-) : AttackUseCase<StatusType.Player> {
+) : AttackUseCase {
     override suspend operator fun invoke(
         target: Int,
-        attacker: StatusData<StatusType.Player>,
+        attacker: StatusData,
         damageType: DamageType,
     ) {
         var actualTarget = target

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/attack/AttackUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/attack/AttackUseCase.kt
@@ -2,12 +2,11 @@ package gamescreen.battle.usecase.attack
 
 import core.domain.item.DamageType
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 
-interface AttackUseCase<T : StatusType> {
+interface AttackUseCase {
     suspend operator fun invoke(
         target: Int,
-        attacker: StatusData<T>,
+        attacker: StatusData,
         damageType: DamageType,
     )
 }

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/condition/ConditionFromEnemyUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/condition/ConditionFromEnemyUseCaseImpl.kt
@@ -1,15 +1,14 @@
 package gamescreen.battle.usecase.condition
 
 import core.domain.status.ConditionType
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import core.usecase.updateparameter.UpdateStatusUseCase
 import gamescreen.battle.service.findtarget.FindTargetService
 
 class ConditionFromEnemyUseCaseImpl(
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
     private val findTargetService: FindTargetService,
-    private val updatePlayerStatusService: UpdateStatusUseCase<StatusType.Player>,
+    private val updatePlayerStatusService: UpdateStatusUseCase,
 ) : ConditionUseCase {
     override suspend fun invoke(
         target: Int,

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/condition/ConditionFromPlayerUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/condition/ConditionFromPlayerUseCaseImpl.kt
@@ -1,15 +1,14 @@
 package gamescreen.battle.usecase.condition
 
 import core.domain.status.ConditionType
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import core.usecase.updateparameter.UpdateStatusUseCase
 import gamescreen.battle.service.findtarget.FindTargetService
 
 class ConditionFromPlayerUseCaseImpl(
-    private val statusDataRepository: StatusDataRepository<StatusType.Enemy>,
+    private val statusDataRepository: StatusDataRepository,
     private val findTargetService: FindTargetService,
-    private val updateMonsterStatusUseCase: UpdateStatusUseCase<StatusType.Enemy>,
+    private val updateMonsterStatusUseCase: UpdateStatusUseCase,
 ) : ConditionUseCase {
     override suspend fun invoke(
         target: Int,

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/findactivetarget/FindActiveTargetUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/findactivetarget/FindActiveTargetUseCase.kt
@@ -5,7 +5,7 @@ import core.domain.status.StatusData
 interface FindActiveTargetUseCase {
 
     operator fun invoke(
-        statusList: List<StatusData<*>>,
+        statusList: List<StatusData>,
         target: Int,
         targetNum: Int,
     ): List<Int>

--- a/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/findactivetarget/FindActiveTargetUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/battle/usecase/findactivetarget/FindActiveTargetUseCaseImpl.kt
@@ -7,7 +7,7 @@ class FindActiveTargetUseCaseImpl(
     private val findTargetService: FindTargetService,
 ) : FindActiveTargetUseCase {
     override fun invoke(
-        statusList: List<StatusData<*>>,
+        statusList: List<StatusData>,
         target: Int,
         targetNum: Int,
     ): List<Int> {

--- a/composeApp/src/commonMain/kotlin/gamescreen/map/usecase/battledecidemonster/DecideBattleMonsterUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/map/usecase/battledecidemonster/DecideBattleMonsterUseCase.kt
@@ -1,7 +1,6 @@
 package gamescreen.map.usecase.battledecidemonster
 
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import gamescreen.map.domain.background.BackgroundCell
 
@@ -12,5 +11,5 @@ interface DecideBattleMonsterUseCase {
      */
     operator fun invoke(
         backgroundCell: BackgroundCell,
-    ): List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>>
+    ): List<Pair<MonsterStatus, StatusData>>
 }

--- a/composeApp/src/commonMain/kotlin/gamescreen/map/usecase/battledecidemonster/DecideBattleMonsterUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/map/usecase/battledecidemonster/DecideBattleMonsterUseCaseImpl.kt
@@ -2,7 +2,6 @@ package gamescreen.map.usecase.battledecidemonster
 
 import core.domain.mapcell.CellType
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import data.monster.MonsterRepository
 import gamescreen.map.domain.background.BackgroundCell
@@ -13,7 +12,7 @@ class DecideBattleMonsterUseCaseImpl(
 ) : DecideBattleMonsterUseCase {
     override fun invoke(
         backgroundCell: BackgroundCell,
-    ): List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>> {
+    ): List<Pair<MonsterStatus, StatusData>> {
         val cellType = backgroundCell.cellType as? CellType.MonsterCell
             ?: return emptyList()
 

--- a/composeApp/src/commonMain/kotlin/gamescreen/map/usecase/battlestart/StartBattleUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/map/usecase/battlestart/StartBattleUseCase.kt
@@ -2,13 +2,12 @@ package gamescreen.map.usecase.battlestart
 
 import core.domain.BattleEventCallback
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import gamescreen.battle.domain.BattleBackgroundType
 
 interface StartBattleUseCase {
     operator fun invoke(
-        monsterList: List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>>,
+        monsterList: List<Pair<MonsterStatus, StatusData>>,
         battleEventCallback: BattleEventCallback = BattleEventCallback.default,
         backgroundType: BattleBackgroundType,
     )

--- a/composeApp/src/commonMain/kotlin/gamescreen/map/usecase/battlestart/StartBattleUseCaseImpl.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/map/usecase/battlestart/StartBattleUseCaseImpl.kt
@@ -4,7 +4,6 @@ import common.DefaultScope
 import core.domain.BattleEventCallback
 import core.domain.BattleResult
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import core.repository.battlemonster.BattleInfoRepository
 import core.repository.event.EventRepository
@@ -28,11 +27,11 @@ class StartBattleUseCaseImpl(
     private val flashRepository: FlashRepository,
     private val attackEffectRepository: AttackEffectRepository,
 
-    private val statusDataRepository: StatusDataRepository<StatusType.Enemy>,
+    private val statusDataRepository: StatusDataRepository,
 ) : StartBattleUseCase, KoinComponent {
 
     override operator fun invoke(
-        monsterList: List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>>,
+        monsterList: List<Pair<MonsterStatus, StatusData>>,
         battleEventCallback: BattleEventCallback,
         backgroundType: BattleBackgroundType,
     ) {
@@ -68,7 +67,7 @@ class StartBattleUseCaseImpl(
     }
 
     // TODO: test作る
-    private fun renameMonster(monsters: List<StatusData<StatusType.Enemy>>): List<StatusData<StatusType.Enemy>> {
+    private fun renameMonster(monsters: List<StatusData>): List<StatusData> {
         val nameNum: MutableMap<String, Int> = mutableMapOf()
         monsters.map {
             it.let {

--- a/composeApp/src/commonMain/kotlin/gamescreen/menu/component/StatusComponentViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/menu/component/StatusComponentViewModel.kt
@@ -1,13 +1,12 @@
 package gamescreen.menu.component
 
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.repository.statusdata.StatusDataRepository
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class StatusComponentViewModel(
-    statusDataRepository: StatusDataRepository<StatusType.Player>,
+    statusDataRepository: StatusDataRepository,
 ) : KoinComponent {
     private val playerStatusRepository: PlayerStatusRepository by inject()
 

--- a/composeApp/src/commonMain/kotlin/gamescreen/menu/item/abstract/itemselect/ItemListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/menu/item/abstract/itemselect/ItemListViewModel.kt
@@ -3,7 +3,6 @@ package gamescreen.menu.item.abstract.itemselect
 import core.PlayerStatusRepositoryName
 import core.domain.AbleType
 import core.domain.item.Item
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.repository.statusdata.StatusDataRepository
 import data.item.ItemRepository
@@ -29,7 +28,7 @@ abstract class ItemListViewModel<T, V : Item> : MenuChildViewModel(),
     protected val indexRepository: IndexRepository by inject()
 
     protected val playerStatusRepository: PlayerStatusRepository by inject()
-    protected val statusDataRepository: StatusDataRepository<StatusType.Player> by inject(
+    protected val statusDataRepository: StatusDataRepository by inject(
         qualifier = PlayerStatusRepositoryName
     )
 

--- a/composeApp/src/commonMain/kotlin/gamescreen/menu/item/abstract/target/UsableTargetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/menu/item/abstract/target/UsableTargetViewModel.kt
@@ -3,7 +3,6 @@ package gamescreen.menu.item.abstract.target
 import core.PlayerStatusRepositoryName
 import core.domain.AbleType
 import core.domain.item.UsableItem
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.repository.statusdata.StatusDataRepository
 import gamescreen.choice.Choice
@@ -18,7 +17,7 @@ import values.Constants.Companion.playerNum
 abstract class UsableTargetViewModel<T, V : UsableItem> : TargetViewModel<T, V>() {
     protected val targetRepository: TargetRepository by inject()
     protected val playerStatusRepository: PlayerStatusRepository by inject()
-    protected val statusDataRepository: StatusDataRepository<StatusType.Player> by inject(
+    protected val statusDataRepository: StatusDataRepository by inject(
         qualifier = PlayerStatusRepositoryName
     )
 

--- a/composeApp/src/commonMain/kotlin/gamescreen/menu/item/equipment/target/EquipmentTargetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/menu/item/equipment/target/EquipmentTargetViewModel.kt
@@ -4,7 +4,6 @@ import common.DefaultScope
 import core.EquipmentBagRepositoryName
 import core.PlayerStatusRepositoryName
 import core.domain.item.equipment.EquipmentData
-import core.domain.status.StatusType
 import core.repository.bag.BagRepository
 import core.repository.player.PlayerStatusRepository
 import core.repository.statusdata.StatusDataRepository
@@ -29,7 +28,7 @@ class EquipmentTargetViewModel(
 ) : TargetViewModel<EquipmentId, EquipmentData>() {
     private val targetRepository: TargetRepository by inject()
     val playerStatusRepository: PlayerStatusRepository by inject()
-    val statusDataRepository: StatusDataRepository<StatusType.Player> by inject(
+    val statusDataRepository: StatusDataRepository by inject(
         qualifier = PlayerStatusRepositoryName
     )
 

--- a/composeApp/src/commonMain/kotlin/gamescreen/menu/item/equipment/user/ToolUserViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/menu/item/equipment/user/ToolUserViewModel.kt
@@ -3,7 +3,6 @@ package gamescreen.menu.item.equipment.user
 import core.EquipmentBagRepositoryName
 import core.domain.item.BagItemData
 import core.domain.item.equipment.EquipmentData
-import core.domain.status.StatusType
 import core.repository.bag.BagRepository
 import core.repository.statusdata.StatusDataRepository
 import data.item.equipment.EquipmentId
@@ -16,7 +15,7 @@ import org.koin.core.component.inject
 import values.Constants
 
 class EquipmentUserViewModel(
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 ) : ItemUserViewModel<EquipmentId, EquipmentData>(),
     KoinComponent {
     override val itemRepository: EquipmentRepository by inject()

--- a/composeApp/src/commonMain/kotlin/gamescreen/menu/item/skill/user/SkillUserViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/menu/item/skill/user/SkillUserViewModel.kt
@@ -1,7 +1,6 @@
 package gamescreen.menu.item.skill.user
 
 import core.domain.item.Skill
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.repository.statusdata.StatusDataRepository
 import data.item.skill.SkillId
@@ -13,7 +12,7 @@ import org.koin.core.component.inject
 import values.Constants
 
 class SkillUserViewModel(
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 ) : ItemUserViewModel<SkillId, Skill>() {
     val repository: PlayerStatusRepository by inject()
 

--- a/composeApp/src/commonMain/kotlin/gamescreen/menu/item/tool/give/ToolGiveUserViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/menu/item/tool/give/ToolGiveUserViewModel.kt
@@ -3,7 +3,6 @@ package gamescreen.menu.item.tool.give
 import core.ToolBagRepositoryName
 import core.domain.item.BagItemData
 import core.domain.item.Tool
-import core.domain.status.StatusType
 import core.repository.bag.BagRepository
 import core.repository.statusdata.StatusDataRepository
 import data.item.tool.ToolId
@@ -26,7 +25,7 @@ import org.koin.core.component.inject
 import values.Constants
 
 class ToolGiveUserViewModel(
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 ) : ItemUserViewModel<ToolId, Tool>(),
     KoinComponent {
     override val itemRepository: ToolRepository by inject()

--- a/composeApp/src/commonMain/kotlin/gamescreen/menu/item/tool/user/ToolUserViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/menu/item/tool/user/ToolUserViewModel.kt
@@ -3,7 +3,6 @@ package gamescreen.menu.item.tool.user
 import core.ToolBagRepositoryName
 import core.domain.item.BagItemData
 import core.domain.item.Tool
-import core.domain.status.StatusType
 import core.repository.bag.BagRepository
 import core.repository.statusdata.StatusDataRepository
 import data.item.tool.ToolId
@@ -16,7 +15,7 @@ import org.koin.core.component.inject
 import values.Constants
 
 class ToolUserViewModel(
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 ) : ItemUserViewModel<ToolId, Tool>(),
     KoinComponent {
     override val itemRepository: ToolRepository by inject()

--- a/composeApp/src/commonMain/kotlin/gamescreen/menu/status/StatusViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/gamescreen/menu/status/StatusViewModel.kt
@@ -2,7 +2,6 @@ package gamescreen.menu.status
 
 import common.Timer
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.menu.SelectableWindowViewModel
 import core.repository.statusdata.StatusDataRepository
 import gamescreen.menu.domain.SelectManager
@@ -12,7 +11,7 @@ import org.koin.core.component.inject
 import values.Constants
 
 class StatusViewModel(
-    private val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    private val statusDataRepository: StatusDataRepository,
 ) : SelectableWindowViewModel(),
     KoinComponent {
     private val menuStateRepository: MenuStateRepository by inject()
@@ -24,7 +23,7 @@ class StatusViewModel(
 
     override var timer: Timer = Timer(200)
 
-    fun getStatusDataAt(id: Int): StatusData<StatusType.Player> {
+    fun getStatusDataAt(id: Int): StatusData {
         return statusDataRepository.getStatusData(id)
     }
 

--- a/composeApp/src/commonMain/kotlin/main/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/main/MainViewModel.kt
@@ -1,6 +1,5 @@
 package main
 
-import core.domain.status.StatusType
 import core.repository.screentype.ScreenTypeRepository
 import core.repository.statusdata.StatusDataRepository
 import data.status.StatusRepository
@@ -9,7 +8,7 @@ import org.koin.core.component.inject
 import values.Constants
 
 class MainViewModel(
-    val statusDataRepository: StatusDataRepository<StatusType.Player>,
+    val statusDataRepository: StatusDataRepository,
     val statusRepository: StatusRepository,
 ) : KoinComponent {
     private val screenTypeRepository: ScreenTypeRepository by inject()

--- a/composeApp/src/commonTest/kotlin/core/domain/status/StatusDataTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/domain/status/StatusDataTest.kt
@@ -11,7 +11,7 @@ class StatusDataTest {
 
         val name = "テスト"
 
-        val TestPlayerStatusActive = StatusData<StatusType.Player>(
+        val TestPlayerStatusActive = StatusData(
             name = name,
             hp = StatusParameterWithMax(
                 maxPoint = MAX_HP,
@@ -23,7 +23,7 @@ class StatusDataTest {
 
         val TestPlayerStatusInActive = TestPlayerStatusActive.setHP(0)
 
-        val TestEnemyStatusActive = StatusData<StatusType.Enemy>(
+        val TestEnemyStatusActive = StatusData(
             name = name,
             hp = StatusParameterWithMax(
                 maxPoint = MAX_HP,

--- a/composeApp/src/commonTest/kotlin/core/usecase/equipment/EquipUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/usecase/equipment/EquipUseCaseImplTest.kt
@@ -8,7 +8,6 @@ import core.domain.status.PlayerStatus
 import core.domain.status.StatusData
 import core.domain.status.StatusDataTest
 import core.domain.status.StatusIncrease
-import core.domain.status.StatusType
 import core.domain.status.param.EXP
 import core.domain.status.param.StatusParameter
 import core.repository.player.PlayerStatusRepository
@@ -29,8 +28,8 @@ class EquipUseCaseImplTest {
     val upATK1 = 10
     val upATK2 = 15
 
-    private val statusDataRepository = object : StatusDataRepository<StatusType.Player> {
-        override val statusDataFlow: StateFlow<List<StatusData<StatusType.Player>>>
+    private val statusDataRepository = object : StatusDataRepository {
+        override val statusDataFlow: StateFlow<List<StatusData>>
             get() = throw NotImplementedError()
 
         private var statusDataList = MutableList(5) {
@@ -39,21 +38,21 @@ class EquipUseCaseImplTest {
             )
         }
 
-        override fun getStatusData(id: Int): StatusData<StatusType.Player> {
+        override fun getStatusData(id: Int): StatusData {
             return statusDataList[id]
         }
 
-        override fun getStatusList(): List<StatusData<StatusType.Player>> {
+        override fun getStatusList(): List<StatusData> {
             throw NotImplementedError()
         }
 
-        override fun setStatusList(statusList: List<StatusData<StatusType.Player>>) {
+        override fun setStatusList(statusList: List<StatusData>) {
             throw NotImplementedError()
         }
 
         override fun setStatusData(
             id: Int,
-            statusData: StatusData<StatusType.Player>,
+            statusData: StatusData,
         ) {
             statusDataList[id] = statusData
         }

--- a/composeApp/src/commonTest/kotlin/core/usecase/heal/MaxHealUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/usecase/heal/MaxHealUseCaseImplTest.kt
@@ -2,7 +2,6 @@ package core.usecase.heal
 
 import core.domain.status.StatusData
 import core.domain.status.StatusDataTest
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
@@ -11,7 +10,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class MaxHealUseCaseImplTest {
-    private val playerStatusRepository = object : StatusDataRepository<StatusType.Player> {
+    private val playerStatusRepository = object : StatusDataRepository {
         private var statusList = MutableList(2) {
             StatusDataTest.TestPlayerStatusActive.run {
                 copy(
@@ -24,25 +23,25 @@ class MaxHealUseCaseImplTest {
                 )
             }
         }
-        override val statusDataFlow: StateFlow<List<StatusData<StatusType.Player>>>
+        override val statusDataFlow: StateFlow<List<StatusData>>
             get() = throw NotImplementedError()
 
-        override fun getStatusData(id: Int): StatusData<StatusType.Player> {
+        override fun getStatusData(id: Int): StatusData {
             return statusList[id]
         }
 
         override fun setStatusData(
             id: Int,
-            statusData: StatusData<StatusType.Player>,
+            statusData: StatusData,
         ) {
             statusList[id] = statusData
         }
 
-        override fun getStatusList(): List<StatusData<StatusType.Player>> {
+        override fun getStatusList(): List<StatusData> {
             return statusList
         }
 
-        override fun setStatusList(statusList: List<StatusData<StatusType.Player>>) {
+        override fun setStatusList(statusList: List<StatusData>) {
             throw NotImplementedError()
         }
     }

--- a/composeApp/src/commonTest/kotlin/core/usecase/item/useskill/UseSkillUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/usecase/item/useskill/UseSkillUseCaseImplTest.kt
@@ -11,7 +11,6 @@ import core.domain.item.skill.AttackSkill
 import core.domain.item.skill.HealSkill
 import core.domain.status.ConditionType
 import core.domain.status.PlayerStatus
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.usecase.updateparameter.UpdateStatusUseCase
 import data.item.skill.SkillId
@@ -52,7 +51,7 @@ class UseSkillUseCaseImplTest {
 
     private lateinit var playerStatusRepository: TestPlayerStatusRepository
 
-    abstract class TestUpdatePlayerStatusUseCase : UpdateStatusUseCase<StatusType.Player> {
+    abstract class TestUpdatePlayerStatusUseCase : UpdateStatusUseCase {
 
         override suspend fun decHP(
             id: Int,
@@ -83,7 +82,7 @@ class UseSkillUseCaseImplTest {
         }
     }
 
-    private lateinit var updatePlayerStatusUseCase: UpdateStatusUseCase<StatusType.Player>
+    private lateinit var updatePlayerStatusUseCase: UpdateStatusUseCase
 
     private val testUseCase = object : TestUpdatePlayerStatusUseCase() {
         override suspend fun incHP(

--- a/composeApp/src/commonTest/kotlin/core/usecase/item/usetool/UseToolUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/usecase/item/usetool/UseToolUseCaseImplTest.kt
@@ -8,7 +8,6 @@ import core.domain.item.TargetType
 import core.domain.item.Tool
 import core.domain.item.tool.HealTool
 import core.domain.status.ConditionType
-import core.domain.status.StatusType
 import core.usecase.updateparameter.UpdatePlayerStatusUseCase
 import core.usecase.updateparameter.UpdateStatusUseCase
 import data.item.tool.ToolId
@@ -59,7 +58,7 @@ class UseToolUseCaseImplTest : KoinTest {
         }
     }
 
-    private val updateStatusService = object : UpdateStatusUseCase<StatusType.Player> {
+    private val updateStatusService = object : UpdateStatusUseCase {
         override suspend fun decHP(
             id: Int,
             amount: Int,

--- a/composeApp/src/commonTest/kotlin/core/usecase/updateparameter/UpdateParameterTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/usecase/updateparameter/UpdateParameterTest.kt
@@ -6,6 +6,7 @@ import core.repository.statusdata.StatusDataRepository
 import kotlinx.coroutines.runBlocking
 import kotlin.test.assertEquals
 
+// fixme テスト作る
 class UpdateParameterTest(
     private val updateStatusUseCase: UpdateStatusUseCase,
     private val statusRepository: StatusDataRepository,

--- a/composeApp/src/commonTest/kotlin/core/usecase/updateparameter/UpdateParameterTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/usecase/updateparameter/UpdateParameterTest.kt
@@ -2,15 +2,14 @@ package core.usecase.updateparameter
 
 import core.domain.status.ConditionType
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import kotlinx.coroutines.runBlocking
 import kotlin.test.assertEquals
 
-class UpdateParameterTest<V : StatusType, T : StatusData<V>>(
-    private val updateStatusUseCase: UpdateStatusUseCase<V>,
-    private val statusRepository: StatusDataRepository<V>,
-    private val status2: T,
+class UpdateParameterTest(
+    private val updateStatusUseCase: UpdateStatusUseCase,
+    private val statusRepository: StatusDataRepository,
+    private val status2: StatusData,
 ) {
     companion object {
         const val HP = 50

--- a/composeApp/src/commonTest/kotlin/core/usecase/updateparameter/UpdateStatusUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/usecase/updateparameter/UpdateStatusUseCaseImplTest.kt
@@ -3,7 +3,6 @@ package core.usecase.updateparameter
 import core.domain.status.ConditionType
 import core.domain.status.StatusData
 import core.domain.status.StatusDataTest
-import core.domain.status.StatusType
 import core.domain.status.param.StatusParameterWithMax
 import core.repository.statusdata.StatusDataRepository
 import kotlinx.coroutines.flow.StateFlow
@@ -28,30 +27,30 @@ class UpdateStatusUseCaseImplTest {
 
     private val status2 = status1.copy()
 
-    private val statusRepository: StatusDataRepository<StatusType.Player> =
-        object : StatusDataRepository<StatusType.Player> {
-            var _statusList: MutableList<StatusData<StatusType.Player>> = mutableListOf(
+    private val statusRepository: StatusDataRepository =
+        object : StatusDataRepository {
+            var _statusList: MutableList<StatusData> = mutableListOf(
                 status1,
                 status2,
             )
-            override val statusDataFlow: StateFlow<List<StatusData<StatusType.Player>>>
+            override val statusDataFlow: StateFlow<List<StatusData>>
                 get() = throw NotImplementedError()
 
-            override fun getStatusData(id: Int): StatusData<StatusType.Player> {
+            override fun getStatusData(id: Int): StatusData {
                 return _statusList[id]
             }
 
-            override fun getStatusList(): List<StatusData<StatusType.Player>> {
+            override fun getStatusList(): List<StatusData> {
                 return _statusList
             }
 
-            override fun setStatusList(statusList: List<StatusData<StatusType.Player>>) {
+            override fun setStatusList(statusList: List<StatusData>) {
                 throw NotImplementedError()
             }
 
             override fun setStatusData(
                 id: Int,
-                statusData: StatusData<StatusType.Player>,
+                statusData: StatusData,
             ) {
                 this._statusList[id] = statusData
             }

--- a/composeApp/src/commonTest/kotlin/data/status/AbstractStatusRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/data/status/AbstractStatusRepositoryTest.kt
@@ -14,7 +14,6 @@ import core.domain.status.StatusIncreaseTest.Companion.TEST_LV2_DEF
 import core.domain.status.StatusIncreaseTest.Companion.TEST_LV2_HP
 import core.domain.status.StatusIncreaseTest.Companion.TEST_LV2_MP
 import core.domain.status.StatusIncreaseTest.Companion.TEST_LV2_SPEED
-import core.domain.status.StatusType
 import core.domain.status.param.EXP
 import core.domain.status.param.StatusParameter
 import data.item.skill.SkillId
@@ -40,7 +39,7 @@ class AbstractStatusRepositoryTest {
                 StatusIncreaseTest.testStatusUpList
             )
 
-        override val statusBaseList: List<Pair<PlayerStatus, StatusData<StatusType.Player>>>
+        override val statusBaseList: List<Pair<PlayerStatus, StatusData>>
             get() = listOf(
                 Pair(
                     PlayerStatus(

--- a/composeApp/src/commonTest/kotlin/gamescreen/battle/service/attackcalc/AttackServiceImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/battle/service/attackcalc/AttackServiceImplTest.kt
@@ -180,7 +180,7 @@ class AttackServiceImplTest : KoinTest {
         def: Int,
         maxPoint: Int,
         rate: Int,
-    ): StatusData<*> {
+    ): StatusData {
         val attacker = StatusDataTest.TestPlayerStatusActive.copy(
             atk = StatusParameter(atk),
         )
@@ -242,7 +242,7 @@ class AttackServiceImplTest : KoinTest {
     private fun rateAttack(
         maxPoint: Int,
         rate: Int,
-    ): StatusData<*> {
+    ): StatusData {
         val attacker = StatusDataTest.TestPlayerStatusActive
 
         val attacked = StatusDataTest.TestEnemyStatusActive.copy(
@@ -303,7 +303,7 @@ class AttackServiceImplTest : KoinTest {
     private fun fixDamage(
         maxPoint: Int,
         amount: Int,
-    ): StatusData<*> {
+    ): StatusData {
         val attacker = StatusDataTest.TestPlayerStatusActive
 
         val attacked = StatusDataTest.TestEnemyStatusActive.copy(

--- a/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/addexp/AddExpUseCaseImplFor2PlayerTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/addexp/AddExpUseCaseImplFor2PlayerTest.kt
@@ -6,7 +6,6 @@ import core.domain.status.StatusData
 import core.domain.status.StatusDataTest
 import core.domain.status.StatusIncrease
 import core.domain.status.StatusIncreaseTest.Companion.testStatusUpList
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.repository.player.PlayerStatusRepositoryImpl
 import core.repository.statusdata.StatusDataRepository
@@ -31,7 +30,7 @@ class AddExpUseCaseImplFor2PlayerTest {
                 testStatusUpList,
             )
 
-        override val statusBaseList: List<Pair<PlayerStatus, StatusData<StatusType.Player>>>
+        override val statusBaseList: List<Pair<PlayerStatus, StatusData>>
             get() = listOf(
                 Pair(
                     testPlayerStatus,
@@ -48,27 +47,27 @@ class AddExpUseCaseImplFor2PlayerTest {
             )
     }
 
-    private val statusDataRepository = object : StatusDataRepository<StatusType.Player> {
-        override val statusDataFlow: StateFlow<List<StatusData<StatusType.Player>>>
+    private val statusDataRepository = object : StatusDataRepository {
+        override val statusDataFlow: StateFlow<List<StatusData>>
             get() = throw NotImplementedError()
 
-        private var list: MutableList<StatusData<StatusType.Player>> = mutableListOf()
+        private var list: MutableList<StatusData> = mutableListOf()
 
-        override fun getStatusData(id: Int): StatusData<StatusType.Player> {
+        override fun getStatusData(id: Int): StatusData {
             return list[id]
         }
 
-        override fun getStatusList(): List<StatusData<StatusType.Player>> {
+        override fun getStatusList(): List<StatusData> {
             return list
         }
 
-        override fun setStatusList(statusList: List<StatusData<StatusType.Player>>) {
+        override fun setStatusList(statusList: List<StatusData>) {
             list = statusList.toMutableList()
         }
 
         override fun setStatusData(
             id: Int,
-            statusData: StatusData<StatusType.Player>,
+            statusData: StatusData,
         ) {
             list[id] = statusData
         }

--- a/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/addexp/AddExpUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/addexp/AddExpUseCaseImplTest.kt
@@ -9,7 +9,6 @@ import core.domain.status.StatusIncreaseTest.Companion.TEST_LV1_MP
 import core.domain.status.StatusIncreaseTest.Companion.TEST_LV2_HP
 import core.domain.status.StatusIncreaseTest.Companion.TEST_LV2_MP
 import core.domain.status.StatusIncreaseTest.Companion.testStatusUpList
-import core.domain.status.StatusType
 import core.repository.player.PlayerStatusRepository
 import core.repository.player.PlayerStatusRepositoryImpl
 import core.repository.statusdata.StatusDataRepository
@@ -32,7 +31,7 @@ class AddExpUseCaseImplTest {
             get() = listOf(
                 testStatusUpList,
             )
-        override val statusBaseList: List<Pair<PlayerStatus, StatusData<StatusType.Player>>>
+        override val statusBaseList: List<Pair<PlayerStatus, StatusData>>
             get() = listOf(
                 Pair(
                     testPlayerStatus,
@@ -41,27 +40,27 @@ class AddExpUseCaseImplTest {
             )
     })
 
-    private val statusDataRepository = object : StatusDataRepository<StatusType.Player> {
-        override val statusDataFlow: StateFlow<List<StatusData<StatusType.Player>>>
+    private val statusDataRepository = object : StatusDataRepository {
+        override val statusDataFlow: StateFlow<List<StatusData>>
             get() = throw NotImplementedError()
 
-        private var list: MutableList<StatusData<StatusType.Player>> = mutableListOf()
+        private var list: MutableList<StatusData> = mutableListOf()
 
-        override fun getStatusData(id: Int): StatusData<StatusType.Player> {
+        override fun getStatusData(id: Int): StatusData {
             return list[id]
         }
 
-        override fun getStatusList(): List<StatusData<StatusType.Player>> {
+        override fun getStatusList(): List<StatusData> {
             return list
         }
 
-        override fun setStatusList(statusList: List<StatusData<StatusType.Player>>) {
+        override fun setStatusList(statusList: List<StatusData>) {
             list = statusList.toMutableList()
         }
 
         override fun setStatusData(
             id: Int,
-            statusData: StatusData<StatusType.Player>,
+            statusData: StatusData,
         ) {
             list[id] = statusData
         }

--- a/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/attack/AttackUseCaseImplFromEnemyTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/attack/AttackUseCaseImplFromEnemyTest.kt
@@ -4,7 +4,6 @@ import core.ModuleCore
 import core.PlayerStatusRepositoryName
 import core.domain.item.DamageType
 import core.domain.status.StatusDataTest
-import core.domain.status.StatusType
 import core.domain.status.param.ParameterType
 import core.domain.status.param.StatusParameter
 import core.domain.status.param.StatusParameterWithMax
@@ -26,12 +25,12 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class AttackUseCaseImplFromEnemyTest : KoinTest {
-    private val attackUseCaseImplFromEnemy: AttackUseCase<StatusType.Enemy> by inject(
+    private val attackUseCaseImplFromEnemy: AttackUseCase by inject(
         qualifier = named(QualifierAttackFromEnemy)
     )
 
     private val statusRepository: StatusRepository by inject()
-    private val statusDataRepository: StatusDataRepository<StatusType.Player> by inject(
+    private val statusDataRepository: StatusDataRepository by inject(
         qualifier = PlayerStatusRepositoryName
     )
 

--- a/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/attack/AttackUseCaseImplFromPlayerTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/attack/AttackUseCaseImplFromPlayerTest.kt
@@ -4,7 +4,6 @@ import core.EnemyStatusRepositoryName
 import core.ModuleCore
 import core.domain.item.DamageType
 import core.domain.status.StatusDataTest
-import core.domain.status.StatusType
 import core.domain.status.param.ParameterType
 import core.domain.status.param.StatusParameter
 import core.domain.status.param.StatusParameterWithMax
@@ -25,7 +24,7 @@ import kotlin.test.assertEquals
 
 
 class AttackUseCaseImplFromPlayerTest : KoinTest {
-    private val attackUseCase: AttackUseCase<StatusType.Player> by inject(
+    private val attackUseCase: AttackUseCase by inject(
         qualifier = named(
             QualifierAttackFromPlayer
         )
@@ -37,7 +36,7 @@ class AttackUseCaseImplFromPlayerTest : KoinTest {
         maxPoint = 100
     )
 
-    private val enemyStatusDataRepository: StatusDataRepository<StatusType.Enemy> by inject(
+    private val enemyStatusDataRepository: StatusDataRepository by inject(
         qualifier = EnemyStatusRepositoryName,
     )
 

--- a/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/condition/ConditionUseCaseImplFromEnemyTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/condition/ConditionUseCaseImplFromEnemyTest.kt
@@ -4,7 +4,6 @@ import core.ModuleCore
 import core.PlayerStatusRepositoryName
 import core.domain.status.ConditionType
 import core.domain.status.StatusDataTest
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import data.ModuleData
 import data.status.StatusRepository
@@ -29,7 +28,7 @@ class ConditionUseCaseImplFromEnemyTest : KoinTest {
 
     private val statusRepository: StatusRepository by inject()
 
-    private val statusDataRepository: StatusDataRepository<StatusType.Player> by inject(
+    private val statusDataRepository: StatusDataRepository by inject(
         qualifier = PlayerStatusRepositoryName
     )
 

--- a/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/condition/ConditionUseCaseImplFromPlayerTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/battle/usecase/condition/ConditionUseCaseImplFromPlayerTest.kt
@@ -4,7 +4,6 @@ import core.EnemyStatusRepositoryName
 import core.ModuleCore
 import core.domain.status.ConditionType
 import core.domain.status.StatusDataTest
-import core.domain.status.StatusType
 import core.repository.statusdata.StatusDataRepository
 import data.ModuleData
 import gamescreen.battle.ModuleBattle
@@ -28,7 +27,7 @@ class ConditionUseCaseImplFromPlayerTest : KoinTest {
         )
     )
 
-    private val enemyStatusDataRepository: StatusDataRepository<StatusType.Enemy> by inject(
+    private val enemyStatusDataRepository: StatusDataRepository by inject(
         qualifier = EnemyStatusRepositoryName,
     )
 

--- a/composeApp/src/commonTest/kotlin/gamescreen/map/usecase/battledecidemonster/DecideBattleMonsterUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/map/usecase/battledecidemonster/DecideBattleMonsterUseCaseImplTest.kt
@@ -3,7 +3,6 @@ package gamescreen.map.usecase.battledecidemonster
 import core.domain.status.MonsterStatusTest.Companion.TestActiveMonster
 import core.domain.status.StatusData
 import core.domain.status.StatusDataTest
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import data.monster.MonsterRepository
 import kotlin.test.Test
@@ -14,7 +13,7 @@ class DecideBattleMonsterUseCaseImplTest {
     @Test
     fun count() {
         monsterRepository = object : MonsterRepository {
-            override fun getMonster(id: Int): Pair<MonsterStatus, StatusData<StatusType.Enemy>> {
+            override fun getMonster(id: Int): Pair<MonsterStatus, StatusData> {
                 return Pair(
                     TestActiveMonster,
                     StatusDataTest.TestEnemyStatusActive,

--- a/composeApp/src/commonTest/kotlin/gamescreen/map/usecase/battleevent/StartEventBattleUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/map/usecase/battleevent/StartEventBattleUseCaseImplTest.kt
@@ -2,7 +2,6 @@ package gamescreen.map.usecase.battleevent
 
 import core.domain.BattleEventCallback
 import core.domain.status.StatusData
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import data.battle.BattleDataRepository
 import data.battle.EventBattleData
@@ -36,7 +35,7 @@ class StartEventBattleUseCaseImplTest {
 
     private val startBattleUseCase = object : StartBattleUseCase {
         override fun invoke(
-            monsterList: List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>>,
+            monsterList: List<Pair<MonsterStatus, StatusData>>,
             battleEventCallback: BattleEventCallback,
             backgroundType: BattleBackgroundType,
         ) {

--- a/composeApp/src/commonTest/kotlin/gamescreen/map/usecase/battlenormal/StartNormalBattleUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/map/usecase/battlenormal/StartNormalBattleUseCaseImplTest.kt
@@ -6,7 +6,6 @@ import core.domain.mapcell.toBattleBackGround
 import core.domain.status.MonsterStatusTest.Companion.TestActiveMonster
 import core.domain.status.StatusData
 import core.domain.status.StatusDataTest
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import core.domain.testMapUiState
 import core.usecase.restart.RestartUseCase
@@ -72,7 +71,7 @@ class StartNormalBattleUseCaseImplTest {
     @Test
     fun notStart() {
         decideBattleMonsterUseCase = object : DecideBattleMonsterUseCase {
-            override fun invoke(backgroundCell: BackgroundCell): List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>> {
+            override fun invoke(backgroundCell: BackgroundCell): List<Pair<MonsterStatus, StatusData>> {
                 throw NotImplementedError()
             }
         }
@@ -105,7 +104,7 @@ class StartNormalBattleUseCaseImplTest {
 
         startBattleUseCase = object : StartBattleUseCase {
             override fun invoke(
-                monsterList: List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>>,
+                monsterList: List<Pair<MonsterStatus, StatusData>>,
                 battleEventCallback: BattleEventCallback,
                 backgroundType: BattleBackgroundType,
             ) {
@@ -153,7 +152,7 @@ class StartNormalBattleUseCaseImplTest {
         }
 
         decideBattleMonsterUseCase = object : DecideBattleMonsterUseCase {
-            override fun invoke(backgroundCell: BackgroundCell): List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>> {
+            override fun invoke(backgroundCell: BackgroundCell): List<Pair<MonsterStatus, StatusData>> {
                 assertEquals(
                     expected = expectedBackgroundCell,
                     actual = backgroundCell,
@@ -165,7 +164,7 @@ class StartNormalBattleUseCaseImplTest {
 
         startBattleUseCase = object : StartBattleUseCase {
             override fun invoke(
-                monsterList: List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>>,
+                monsterList: List<Pair<MonsterStatus, StatusData>>,
                 battleEventCallback: BattleEventCallback,
                 backgroundType: BattleBackgroundType,
             ) {
@@ -230,14 +229,14 @@ class StartNormalBattleUseCaseImplTest {
         }
 
         decideBattleMonsterUseCase = object : DecideBattleMonsterUseCase {
-            override fun invoke(backgroundCell: BackgroundCell): List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>> {
+            override fun invoke(backgroundCell: BackgroundCell): List<Pair<MonsterStatus, StatusData>> {
                 return expectedMonsterList
             }
         }
 
         startBattleUseCase = object : StartBattleUseCase {
             override fun invoke(
-                monsterList: List<Pair<MonsterStatus, StatusData<StatusType.Enemy>>>,
+                monsterList: List<Pair<MonsterStatus, StatusData>>,
                 battleEventCallback: BattleEventCallback,
                 backgroundType: BattleBackgroundType,
             ) {

--- a/composeApp/src/commonTest/kotlin/gamescreen/map/usecase/battlestart/StartBattleUseCaseImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/gamescreen/map/usecase/battlestart/StartBattleUseCaseImplTest.kt
@@ -4,7 +4,6 @@ import core.ModuleCore
 import core.domain.status.MonsterStatusTest.Companion.TestActiveMonster
 import core.domain.status.StatusData
 import core.domain.status.StatusDataTest
-import core.domain.status.StatusType
 import core.domain.status.monster.MonsterStatus
 import core.repository.battlemonster.BattleInfoRepository
 import core.repository.event.EventRepository
@@ -179,25 +178,25 @@ class StartBattleUseCaseImplTest : KoinTest {
                     throw NotImplementedError()
                 }
             },
-            statusDataRepository = object : StatusDataRepository<StatusType.Enemy> {
-                override val statusDataFlow: StateFlow<List<StatusData<StatusType.Enemy>>>
+            statusDataRepository = object : StatusDataRepository {
+                override val statusDataFlow: StateFlow<List<StatusData>>
                     get() = throw NotImplementedError()
 
-                override fun getStatusData(id: Int): StatusData<StatusType.Enemy> {
+                override fun getStatusData(id: Int): StatusData {
                     throw NotImplementedError()
                 }
 
-                override fun getStatusList(): List<StatusData<StatusType.Enemy>> {
+                override fun getStatusList(): List<StatusData> {
                     throw NotImplementedError()
                 }
 
-                override fun setStatusList(statusList: List<StatusData<StatusType.Enemy>>) {
+                override fun setStatusList(statusList: List<StatusData>) {
                     checkMonsterStatus++
                 }
 
                 override fun setStatusData(
                     id: Int,
-                    statusData: StatusData<StatusType.Enemy>,
+                    statusData: StatusData,
                 ) {
                     throw NotImplementedError()
                 }


### PR DESCRIPTION
- 間違った対象にinjectできる

- キャストのエラーがでる

など意外とメリットがなかったので削除